### PR TITLE
area-weighting workflow

### DIFF
--- a/exploratory_scripts/scratch/katie-area-weighting.Rmd
+++ b/exploratory_scripts/scratch/katie-area-weighting.Rmd
@@ -1,0 +1,367 @@
+---
+title: "area-normalized-streamcat"
+author: "Katie Willi"
+date: "2025-03-18"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+library(dataRetrieval)
+library(nhdplusTools)
+library(sf)
+library(tidyverse)
+library(mapview)
+library(nngeo) # for visualizing the finalized watersheds, smooth out strange holes from joining a bunch of disparate catchments
+
+# Optional preview water source locations
+mapviewOptions(fgb = FALSE, 
+               georaster = FALSE, 
+               basemaps = c("Esri.WorldTopoMap",
+                            "Esri.WorldImagery"))
+```
+
+Let's do this on one site, 07103703. 
+
+This is the code to grab the catchment the gage is within, then split it into its upstream/downstream components:
+
+```{r}
+gage <- whatNWISdata(siteNumber = "07103703") %>%
+  .[1,] %>%
+  st_as_sf(coords = c("dec_long_va", "dec_lat_va"), crs = 4326)
+
+# Get flowlines at the point
+flowline <- nhdplusTools::get_nhdplus(AOI = gage, t_srs = 4326)
+
+# Snap point to the nearest NHD flowline feature
+nearest_points <- st_nearest_points(gage, flowline)
+snapped_points_sf <- st_cast(nearest_points, "POINT")[2,]
+
+# Clip/split gage catchment to the upstream and downstream portion
+upstream_termination <- get_split_catchment(snapped_points_sf, upstream = F)[2,]
+downstream_termination <- st_difference(get_split_catchment(snapped_points_sf, upstream = F)[1,], upstream_termination)
+
+mapview(gage, col.region = "white") + mapview(upstream_termination, col.regions = "gold") + mapview(downstream_termination, col.region = "blue")
+```
+
+
+Next, we can use that split data to get a nice watershed for 07103703:
+
+```{r}
+# Read NHD flow network
+nhd <- readr::read_csv('data/nhd_flow_network.csv')
+
+# Get upstream trace
+upstream <- nhdplusTools::get_UT(nhd, flowline$comid) %>%
+  tibble::as_tibble() %>%
+  dplyr::rename(comid_list = value) %>%
+  dplyr::distinct(comid_list, .keep_all = TRUE)
+
+# Get catchments and combine
+perfect_watershed <- upstream$comid_list %>%
+  map(~nhdplusTools::get_nhdplus(comid = .,
+                                 realization='catchment',
+                                 t_srs = 4326)) %>%
+  dplyr::bind_rows() %>%
+  dplyr::distinct(featureid, .keep_all=TRUE) %>%
+  dplyr::filter(featureid != flowline$comid) %>%
+  dplyr::bind_rows(., upstream_termination) %>%
+  dplyr::summarize() %>%
+  nngeo::st_remove_holes()
+
+mapview(perfect_watershed, 
+        col.regions = "transparent", 
+        color = "red", 
+        lwd = 5, 
+        alpha.regions = 0) +
+  mapview(upstream_termination, col.regions = "gold") + 
+  mapview(downstream_termination, col.region = "blue") +
+  mapview(gage, col.region = "white")
+```
+
+For both the entire watershed (the "red" sf object), and for the catchment (the combination of the gold and blue object), let's grab our streamcat data and store that data in streamcat_WS_vars and streamcat_CAT_vars, respectively.
+
+```{r}
+# This is what's available on StreamCat related to lithology. Likely not identical to what
+# was used by Abby but hopefully good swap:
+lithology_vars <- c("PctAlkIntruVol", "PctWater",
+                    "PctSilicic",      "PctSalLake",    
+                    "PctNonCarbResid", "PctHydric",      
+                    "PctGlacTilLoam",  "PctGlacTilCrs",  
+                    "PctGlacTilClay",  "PctGlacLakeFine",
+                    "PctGlacLakeCrs",  "PctExtruVol",   
+                    "PctEolFine",      "PctEolCrs",      
+                    "PctColluvSed",    "PctCoastCrs",    
+                    "PctCarbResid",    "PctAlluvCoast")
+
+# Urban cover (add all together to get percent of total urban cover): 
+# Many available years. Which do we want to use? For now using 2011:
+urban_cover <- c("PctUrbOp2019", "PctUrbMd2019", "PctUrbLo2019", "PctUrbHi2019")
+
+# PRISM mean precip for 1981-2010 OR 1991-2020
+prism_precip <- c("Precip8110", "Precip9120")
+
+# These are all the variables Fred was interested in for describing flow
+# in his work. Likely a good starting point for our needs, too. 
+fred_vars <- c("CanalDens", 
+               # BFI
+               "BFI", 
+               #NLCD 2019
+               "PctOw2019", "PctIce2019", "PctUrbOp2019", "PctUrbLo2019", "PctUrbMd2019", "PctUrbHi2019",
+               "PctBl2019", "PctDecid2019", "PctConif2019", "PctMxFst2019", "PctShrb2019",  "PctGrs2019", 
+               "PctHay2019", "PctCrop2019",  "PctWdWet2019", "PctHbWet2019", 
+               # Dam Info
+               "DamDens", "DamNIDStor", "DamNrmStor",
+               # Elevation
+               "Elev", 
+               # Impervious Surfaces across a bunch of years:
+               "PctImp2006", "PctImp2008", "PctImp2011", "PctImp2001",
+               "PctImp2013", "PctImp2019", "PctImp2016", "PctImp2004",
+               # PRISM 1991-2020
+               "Precip9120", "Tmax9120", "Tmean9120", "Tmin9120",
+               # STATSGO variables:
+               "Clay", "Sand", "Silt", "WtDep", "Om", "Perm", "RckDep")
+
+streamcat_WS_vars <- StreamCatTools::sc_get_data(metric = paste(c(lithology_vars, urban_cover, prism_precip, fred_vars), collapse = ","),
+                                                 aoi = 'watershed', 
+                                                 comid = flowline$comid) 
+
+streamcat_CAT_vars <- StreamCatTools::sc_get_data(metric = paste(c(lithology_vars, urban_cover, prism_precip, fred_vars), collapse = ","),
+                                                  aoi = 'catchment',
+                                                  comid = flowline$comid) #%>%
+# remove variables we don't particularly care about that get returned:
+# select(-contains("AREASQKM"))
+```
+
+We want to reduce the weight of the downstream catchment in the watershed ("red" outline) statistics to match the area that actually contributes to the watershed (i.e., replace the whole catchment with the "gold" area contribution). The code below will do that for us. There's a lot of annoying column name matching-up that needs to happen ("watershed" streamcat vars have WS appended to them, "catchment" streamcat vars have CAT appended to them), as well as some area-fractioning that is a bit complex but I tried my best to keep it as simple as possible!
+
+```{r}
+# calculate the upstream/downstream areas from our termination objects
+upstream_area <- as.numeric(st_area(upstream_termination))/1000000 # area returned in sq. meters, convert to sqkm
+downstream_area <- as.numeric(st_area(downstream_termination))/1000000 # area returned in sq. meters, convert to sqkm
+
+# fraction of the upstream catchment area that makes up the total catchment area
+upstream_frac <-  as.numeric(st_area(upstream_termination) / (st_area(downstream_termination) + st_area(upstream_termination)))
+#... example: "Only 67.7% of the whole associated catchment is actually upstream of our gage"
+
+# Get watershed and catchment areas in km:
+# found in our streamcat variable files
+watershed_area <- streamcat_WS_vars$WSAREASQKM
+catchment_area <- streamcat_CAT_vars$CATAREASQKM
+
+# calculate area of the watershed EXCLUDING the catchment
+#Basically, red watershed minus (gold+blue)
+remaining_area <- watershed_area - catchment_area
+
+# get all column names that we want to update:
+watershed_cols <- names(streamcat_WS_vars)[!names(streamcat_WS_vars) %in% c("COMID", "WSAREASQKM", "CATAREASQKM", "AREASQKM")]
+catchment_cols <- names(streamcat_CAT_vars)[!names(streamcat_CAT_vars) %in% c("COMID", "WSAREASQKM", "CATAREASQKM", "AREASQKM")]
+
+# create mapping between WS and CAT variables since WS AND CAT are appended to our streamcat vars:
+ws_base_names <- gsub("WS$", "", watershed_cols)
+cat_base_names <- gsub("CAT$", "", catchment_cols)
+
+# get the common "base" variable names (ie without CAT and WS appended to them)
+common_base_names <- intersect(ws_base_names, cat_base_names)
+
+# create a list to link WS variables to CAT variables
+var_mapping <- list()
+for (base_name in common_base_names) {
+  ws_var <- watershed_cols[ws_base_names == base_name]
+  cat_var <- catchment_cols[cat_base_names == base_name]
+  
+  # only add if we found exactly one match for each
+  # this should never happen but to be safe
+  if (length(ws_var) == 1 && length(cat_var) == 1) {
+    var_mapping[[ws_var]] <- cat_var
+  }
+}
+
+# set variable_names to the WS variables that have CAT counterparts
+variable_names <- names(var_mapping)
+
+# create result data frame (will look identical to streamcat_WS_vars but
+# with updated vals, so starting with that):
+normalized_watershed_stats <- streamcat_WS_vars
+
+# calculate area-normalized values for each watershed variable
+# with a for loop:
+for (ws_var in variable_names) {
+  # get corresponding catchment variable
+  cat_var <- var_mapping[[ws_var]]
+  
+  # get associated watershed and catchment values
+  ws_val <- streamcat_WS_vars[[ws_var]]
+  cat_val <- streamcat_CAT_vars[[cat_var]]
+  
+  # for percent variables, we need to convert to actual area first...
+  # Soo, determine if this is a percent variable (starts with "PCT")
+  if (grepl("^PCT", ws_var)) {
+    # for percent variables, we need to extract true amt from the %:
+    ws_amount <- (ws_val * watershed_area) / 100
+    cat_amount <- (cat_val * catchment_area) / 100
+    
+    # Calculate amount in the rest of the watershed (outside the catchment)
+    rest_amount <- ws_amount - cat_amount
+    
+    # If we know the upstream stat (ie the gold), we could use it directly
+    # but we don't so we'll assume the upstream portion has the same 
+    # characteristics as the whole catchment (gold+blue)
+    upstream_amount <- cat_amount * upstream_frac
+    
+    # Calculate new watershed amount with only the upstream cat (gold) portion
+    new_ws_amount <- rest_amount + upstream_amount
+    
+    # Convert back to percentage
+    normalized_watershed_stats[[ws_var]] <- new_ws_amount * 100 / (remaining_area + upstream_area)
+  } else {
+    # For non-percent variables (like density or average values), 
+    # we need to handle differently based on the type of variable
+    
+    # Calculate contribution from outside the catchment
+    rest_val <- (ws_val * watershed_area - cat_val * catchment_area) / remaining_area
+    
+    # again, assume upstream (gold) has same value as catchment (gold plus blue)
+    upstream_val <- cat_val
+    
+    # Calculate new watershed value
+    normalized_watershed_stats[[ws_var]] <- (rest_val * remaining_area + upstream_val * upstream_area) / 
+      (remaining_area + upstream_area)
+  }
+}
+
+# update area values
+normalized_watershed_stats$WSAREASQKM <- remaining_area + upstream_area
+normalized_watershed_stats$CATAREASQKM <- upstream_area
+
+```
+
+
+Now, we can compare the orginal WS streamcat stats to our area-normalized, updated stats:
+
+EX: which variables changed the most, do the numbers/changes make sense, etc. etc. 
+
+I actually just had Claude do this code below, but it's low-key a great starting point for exploring the data:
+
+```{r}
+# Create the comparison dataframe
+create_comparison <- function() {
+  # Match variables between watershed and catchment data
+  ws_vars <- names(streamcat_WS_vars)
+  cat_vars <- names(streamcat_CAT_vars)
+  
+  # Create a data frame from the values
+  result <- map_dfr(setdiff(ws_vars, c("COMID", "WSAREASQKM", "CATAREASQKM", "AREASQKM")), function(ws_var) {
+    # Get the base name
+    base_name <- gsub("WS$", "", ws_var)
+    
+    # Find matching catchment variable
+    cat_var <- paste0(base_name, "CAT")
+    
+    # Skip if no matching catchment variable
+    if (!cat_var %in% cat_vars) {
+      return(NULL)
+    }
+    
+    # Get values
+    ws_val <- streamcat_WS_vars[[ws_var]]
+    cat_val <- streamcat_CAT_vars[[cat_var]]
+    norm_val <- normalized_watershed_stats[[ws_var]]
+    
+    # Return as a tibble row
+    tibble(
+      variable = base_name,
+      original_ws = ws_val,
+      original_cat = cat_val,
+      normalized = norm_val,
+      abs_diff = abs(norm_val - ws_val),
+      percent_change = if(ws_val != 0) (norm_val - ws_val) / ws_val * 100 else NA,
+      is_percent = grepl("^PCT", ws_var)
+    )
+  })
+  
+  # Add category information
+  result <- result %>%
+    mutate(category = case_when(
+      grepl("PctAlk|PctWater|PctSili|PctSalLake|PctNonCarb|PctHydric|PctGlacTil|PctGlacLake|PctExtru|PctEol|PctColluv|PctCoast|PctCarb|PctAlluv", variable) ~ "Lithology",
+      grepl("PctUrb", variable) ~ "Urban",
+      grepl("Precip", variable) ~ "Precipitation",
+      grepl("PctOw|PctIce|PctBl|PctDecid|PctConif|PctMxFst|PctShrb|PctGrs|PctHay|PctCrop|PctWdWet|PctHbWet", variable) ~ "Land Cover",
+      grepl("Dam", variable) ~ "Dams",
+      grepl("PctImp", variable) ~ "Imperviousness",
+      grepl("Tmax|Tmin|Tmean", variable) ~ "Temperature",
+      grepl("Clay|Sand|Silt|WtDep|Om|Perm|RckDep", variable) ~ "Soil",
+      TRUE ~ "Other"
+    ))
+  
+  # Sort by absolute percent change
+  result %>% arrange(desc(abs(percent_change)))
+}
+
+# Create the comparison dataframe
+comparison_df <- create_comparison()
+
+# View the top 10 most affected variables
+top10 <- comparison_df %>% head(10)
+print(top10)
+
+# Summarize by category
+category_summary <- comparison_df %>%
+  group_by(category) %>%
+  summarize(
+    n_variables = n(),
+    avg_abs_change = mean(abs(percent_change), na.rm = TRUE),
+    max_abs_change = max(abs(percent_change), na.rm = TRUE),
+    most_affected_var = variable[which.max(abs(percent_change))]
+  ) %>%
+  arrange(desc(avg_abs_change))
+
+print(category_summary)
+
+# Create a plot showing the top 10 changes
+ggplot(top10, aes(x = reorder(variable, abs(percent_change)), y = percent_change)) +
+  geom_col(aes(fill = percent_change > 0)) +
+  coord_flip() +
+  labs(
+    title = "Top 10 Variables Most Affected by Normalization",
+    x = "Variable",
+    y = "Percent Change (%)"
+  ) +
+  theme_minimal() +
+  scale_fill_manual(
+    values = c("firebrick", "forestgreen"),
+    name = "Direction",
+    labels = c("Decrease", "Increase")
+  )
+
+# Create a wide format for easier comparison
+comparison_wide <- comparison_df %>%
+  select(variable, category, original_ws, original_cat, normalized) %>%
+  mutate(across(c(original_ws, original_cat, normalized), round, 2))
+
+# Print wide format for the top 10
+print(comparison_wide %>% head(10))
+
+# Create a normalized vs original plot for the top 10
+top10_long <- top10 %>%
+  select(variable, original_ws, normalized) %>%
+  pivot_longer(
+    cols = c(original_ws, normalized),
+    names_to = "type",
+    values_to = "value"
+  )
+
+ggplot(top10_long, aes(x = reorder(variable, value), y = value, fill = type)) +
+  geom_bar(stat = "identity", position = "dodge") +
+  coord_flip() +
+  labs(
+    title = "Comparison of Original vs. Normalized Values",
+    x = "Variable",
+    y = "Value"
+  ) +
+  theme_minimal() +
+  scale_fill_brewer(
+    palette = "Set1",
+    name = "Value Type",
+    labels = c("Normalized", "Original Watershed")
+  )
+```


### PR DESCRIPTION
Hi Juan,

This PR adds a scratch workflow to normalize StreamCat variables based on the actual upstream contributing area of a watershed. The approach calculates the fraction of catchment that contributes to the gage, then adjusts watershed statistics to reflect only the relevant upstream portions. At the bottom I made some visualization tools to compare original vs. normalized statistics and identify the variables most affected by this normalization (or rather, Claude did haha).

Currently, it's only being run on the test site you shared with me but I'm hopeful you can use what's here as a starting point to use across all sites. The slowest part is downloading/accessing the NHD table to I'd be sure load that in outside of any sort of iteration you do.

Looking forward to your thoughts!
Katie